### PR TITLE
Add admin dashboard frontend scaffold

### DIFF
--- a/public/admin/dashboard.php
+++ b/public/admin/dashboard.php
@@ -1,0 +1,95 @@
+<?php
+require_once __DIR__ . '/../includes/header.php';
+require_once __DIR__ . '/../includes/sidebar.php';
+?>
+<div class="grid gap-6 p-6">
+  <!-- KPI Cards -->
+  <section aria-labelledby="kpi-heading">
+    <h2 id="kpi-heading" class="sr-only">Key Performance Indicators</h2>
+    <div id="kpi-cards" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6 gap-4"></div>
+    <div id="settings-card" class="mt-4"></div>
+  </section>
+
+  <!-- Approval Queue -->
+  <section aria-labelledby="approval-heading" class="bg-white rounded-2xl shadow-sm">
+    <h2 id="approval-heading" class="text-lg font-semibold p-4 border-b">Pending Purchase Requests</h2>
+    <div class="overflow-x-auto">
+      <table id="approval-queue" class="min-w-full text-sm">
+        <thead class="bg-gray-50 text-left text-xs uppercase sticky top-0">
+          <tr>
+            <th class="p-2">PR No</th>
+            <th class="p-2">Requester</th>
+            <th class="p-2 text-center">Items</th>
+            <th class="p-2 text-right">Est. Total</th>
+            <th class="p-2">Age</th>
+            <th class="p-2 text-center">Action</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- Alerts & Flags -->
+  <section aria-labelledby="alerts-heading" class="bg-white rounded-2xl shadow-sm">
+    <div class="flex items-center justify-between border-b p-4">
+      <h2 id="alerts-heading" class="text-lg font-semibold">Alerts &amp; Flags</h2>
+      <div id="alert-tabs" class="flex space-x-4 text-sm">
+        <button data-filter="all" class="pb-1 border-b-2 border-blue-500">All</button>
+        <button data-filter="red" class="pb-1">Red</button>
+        <button data-filter="amber" class="pb-1">Amber</button>
+        <button data-filter="green" class="pb-1">Green</button>
+      </div>
+    </div>
+    <ul id="alerts-list"></ul>
+  </section>
+
+  <!-- Cost Trend -->
+  <section aria-labelledby="trend-heading" class="bg-white rounded-2xl shadow-sm">
+    <h2 id="trend-heading" class="text-lg font-semibold p-4 border-b">Cost Trend (12 months)</h2>
+    <div id="cost-trend" class="p-4 overflow-x-auto"></div>
+  </section>
+
+  <!-- Truck Rankings -->
+  <section aria-labelledby="rankings-heading" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <h2 id="rankings-heading" class="sr-only">Truck Rankings</h2>
+    <div class="bg-white rounded-2xl shadow-sm">
+      <h3 class="text-lg font-semibold p-4 border-b">Highest Cost (last 6 months)</h3>
+      <div class="overflow-x-auto">
+        <table id="rank-high" class="min-w-full text-sm">
+          <thead class="bg-gray-50 text-left text-xs uppercase">
+            <tr><th class="p-2">#</th><th class="p-2">Plate</th><th class="p-2">Model</th><th class="p-2 text-right">Cost</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+    <div class="bg-white rounded-2xl shadow-sm">
+      <h3 class="text-lg font-semibold p-4 border-b">Most Repairs (last 6 months)</h3>
+      <div class="overflow-x-auto">
+        <table id="rank-repairs" class="min-w-full text-sm">
+          <thead class="bg-gray-50 text-left text-xs uppercase">
+            <tr><th class="p-2">#</th><th class="p-2">Plate</th><th class="p-2">Model</th><th class="p-2 text-right">Repairs</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- Inventory At-a-Glance -->
+  <section aria-labelledby="inventory-heading" class="bg-white rounded-2xl shadow-sm">
+    <div class="flex items-center justify-between p-4 border-b">
+      <h2 id="inventory-heading" class="text-lg font-semibold">Inventory At-a-Glance</h2>
+      <button disabled class="px-3 py-1.5 bg-gray-200 text-gray-600 rounded cursor-not-allowed">Go to Inventory</button>
+    </div>
+    <ul id="low-stock-list"></ul>
+  </section>
+
+  <!-- Recent Activity Feed -->
+  <section aria-labelledby="activity-heading" class="bg-white rounded-2xl shadow-sm">
+    <h2 id="activity-heading" class="text-lg font-semibold p-4 border-b">Recent Activity</h2>
+    <ul id="activity-feed"></ul>
+  </section>
+</div>
+<?php require_once __DIR__ . '/../includes/footer.php'; ?>

--- a/public/assets/data/admin_dashboard.json
+++ b/public/assets/data/admin_dashboard.json
@@ -1,0 +1,52 @@
+{
+  "kpis": {
+    "fleetSize": 58,
+    "inServicePct": 86,
+    "trucksInRepair": 4,
+    "mtdCost": 427500,
+    "qoqChangePct": -8.4,
+    "mtdDowntimeHrs": 112
+  },
+  "pendingPRs": [
+    {"id":1,"prNo":"PR-2025-00123","requesterName":"J. Dela Cruz","itemsCount":3,"estTotal":48500,"createdAt":"2025-08-17T02:10:00Z"},
+    {"id":2,"prNo":"PR-2025-00124","requesterName":"M. Santos","itemsCount":1,"estTotal":12500,"createdAt":"2025-08-12T08:35:00Z"}
+  ],
+  "alerts":[
+    {"id":1,"truckPlate":"ABC-1234","severity":"red","message":"MoM cost +42%","createdAt":"2025-08-22T03:10:00Z"},
+    {"id":2,"truckPlate":"XYZ-9876","severity":"amber","message":"Repairs >5 in 90d","createdAt":"2025-08-21T11:00:00Z"}
+  ],
+  "monthlyCosts":[
+    {"month":"2024-09","total":210000,"parts":110000,"labor":100000},
+    {"month":"2024-10","total":195000,"parts":90000,"labor":105000},
+    {"month":"2024-11","total":205000,"parts":100000,"labor":105000},
+    {"month":"2024-12","total":225000,"parts":120000,"labor":105000},
+    {"month":"2025-01","total":215000,"parts":110000,"labor":105000},
+    {"month":"2025-02","total":220000,"parts":115000,"labor":105000},
+    {"month":"2025-03","total":230000,"parts":125000,"labor":105000},
+    {"month":"2025-04","total":240000,"parts":135000,"labor":105000},
+    {"month":"2025-05","total":245000,"parts":140000,"labor":105000},
+    {"month":"2025-06","total":250000,"parts":145000,"labor":105000},
+    {"month":"2025-07","total":255000,"parts":150000,"labor":105000},
+    {"month":"2025-08","total":235000,"parts":130000,"labor":105000}
+  ],
+  "rankings": {
+    "highestCost":[
+      {"rank":1,"truckPlate":"ABC-1234","model":"Isuzu NPR","value":182000},
+      {"rank":2,"truckPlate":"QWE-2233","model":"Fuso Canter","value":164000}
+    ],
+    "mostRepairs":[
+      {"rank":1,"truckPlate":"XYZ-9876","model":"Hyundai HD65","value":9},
+      {"rank":2,"truckPlate":"LMN-4455","model":"Isuzu NQR","value":8}
+    ]
+  },
+  "lowStock":[
+    {"sku":"BRK-PA-001","name":"Brake Pad Set","onHand":6,"minLevel":10,"locations":["Main","Bin A3"]},
+    {"sku":"FLT-OL-010","name":"Oil Filter","onHand":12,"minLevel":25,"locations":["Main","Bin B1"]}
+  ],
+  "activity":[
+    {"id":1,"icon":"ticket","text":"Ticket #1456 created for ABC-1234","timestamp":"2025-08-22T08:30:00Z"},
+    {"id":2,"icon":"wo","text":"WO #778 moved to In Progress","timestamp":"2025-08-22T09:10:00Z"},
+    {"id":3,"icon":"pr","text":"PR-2025-00123 submitted for approval","timestamp":"2025-08-21T15:00:00Z"}
+  ],
+  "thresholds": {"costMoM":"30","repairs90d":"5","downtime30dHrs":"40"}
+}

--- a/public/assets/js/dashboard.js
+++ b/public/assets/js/dashboard.js
@@ -1,0 +1,198 @@
+import { getAdminDashboardData } from './mockApi.js';
+import { formatCurrency, timeAgo, ageBadgeClasses, severityClasses } from './utils.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const data = await getAdminDashboardData();
+    renderKpis(data.kpis, data.thresholds);
+    renderApprovalQueue(data.pendingPRs);
+    renderAlerts(data.alerts);
+    renderTrendSvg(data.monthlyCosts);
+    renderRankings(data.rankings);
+    renderLowStock(data.lowStock);
+    renderActivity(data.activity);
+  } catch (e) {
+    console.error(e);
+  }
+});
+
+function renderKpis(kpis, thresholds){
+  const wrapper = document.getElementById('kpi-cards');
+  if(!wrapper) return;
+  const items = [
+    { label:'Fleet Size', value:kpis.fleetSize, icon:'🚚'},
+    { label:'In-service %', value:`${kpis.inServicePct}%`, icon:'🛠️'},
+    { label:'Trucks In Repair', value:kpis.trucksInRepair, icon:'🔧'},
+    { label:'MTD Maintenance Cost', value:formatCurrency(kpis.mtdCost), icon:'💰'},
+    { label:'QoQ % Change', value:`${kpis.qoqChangePct}%`, icon:'📉', change:kpis.qoqChangePct},
+    { label:'MTD Downtime (hrs)', value:kpis.mtdDowntimeHrs, icon:'⏱️'}
+  ];
+  wrapper.innerHTML = items.map(item => {
+    let changeChip='';
+    if(item.label==='QoQ % Change'){
+      const dir = item.change >0 ? '▲' : '▼';
+      const col = item.change >0 ? 'bg-green-50 text-green-600' : 'bg-red-50 text-red-600';
+      changeChip = `<span class="ml-2 px-2 py-0.5 text-xs rounded ${col}">${dir}</span>`;
+    }
+    return `<div class="rounded-2xl shadow-sm p-5 bg-white flex items-center justify-between">
+      <div>
+        <p class="text-sm text-gray-500">${item.label}</p>
+        <p class="text-xl font-semibold">${item.value}${changeChip}</p>
+      </div>
+      <span class="text-2xl" aria-hidden="true">${item.icon}</span>
+    </div>`;
+  }).join('');
+
+  // thresholds mini card
+  const settings = document.getElementById('settings-card');
+  settings.innerHTML = `<div class="rounded-2xl shadow-sm p-5 bg-white">
+    <h3 class="font-semibold mb-2">Alert Thresholds</h3>
+    <ul class="text-sm space-y-1">
+      <li>Cost MoM &gt; ${thresholds.costMoM}%</li>
+      <li>Repairs in 90d &gt; ${thresholds.repairs90d}</li>
+      <li>Downtime 30d &gt; ${thresholds.downtime30dHrs} hrs</li>
+    </ul>
+    <button class="mt-3 px-3 py-1.5 bg-gray-200 text-gray-600 rounded cursor-not-allowed" disabled>Edit thresholds</button>
+  </div>`;
+}
+
+function renderApprovalQueue(prs){
+  const body = document.querySelector('#approval-queue tbody');
+  if(!body) return;
+  if(!prs.length){
+    body.innerHTML = `<tr><td colspan="6" class="text-center py-4 text-sm text-gray-500">No pending requests</td></tr>`;
+    return;
+  }
+  body.innerHTML = prs.map(pr => {
+    const ageDays = Math.floor((Date.now() - new Date(pr.createdAt)) / (1000*60*60*24));
+    return `<tr class="hover:bg-gray-50 focus-within:bg-gray-50">
+      <td class="p-2">${pr.prNo}</td>
+      <td class="p-2">${pr.requesterName}</td>
+      <td class="p-2 text-center">${pr.itemsCount}</td>
+      <td class="p-2 text-right">${formatCurrency(pr.estTotal)}</td>
+      <td class="p-2"><span class="px-2 py-1 rounded text-xs ${ageBadgeClasses(ageDays)}">${ageDays}d</span></td>
+      <td class="p-2 text-center"><button disabled class="px-2 py-1 bg-gray-200 text-gray-500 rounded cursor-not-allowed" title="Review disabled">Review</button></td>
+    </tr>`;
+  }).join('');
+}
+
+function renderAlerts(alerts){
+  const list = document.getElementById('alerts-list');
+  const tabs = document.getElementById('alert-tabs');
+  let current = 'all';
+
+  function update(){
+    const filtered = alerts.filter(a => current==='all' ? true : a.severity===current);
+    if(!filtered.length){
+      list.innerHTML = `<li class="text-sm text-gray-500 p-4">No alerts</li>`;
+      return;
+    }
+    list.innerHTML = filtered.map(a => `<li class="p-4 border-b last:border-0 flex justify-between" tabindex="0">
+      <div>
+        <p class="font-medium">${a.truckPlate} <span class="ml-2 px-2 py-0.5 text-xs rounded ${severityClasses(a.severity)}">${a.severity}</span></p>
+        <p class="text-sm text-gray-600">${a.message}</p>
+      </div>
+      <time class="text-xs text-gray-500">${timeAgo(a.createdAt)}</time>
+    </li>`).join('');
+  }
+
+  tabs.addEventListener('click', e => {
+    const btn = e.target.closest('button');
+    if(!btn) return;
+    current = btn.dataset.filter;
+    [...tabs.querySelectorAll('button')].forEach(b=>b.classList.remove('border-b-2','border-blue-500'));
+    btn.classList.add('border-b-2','border-blue-500');
+    update();
+  });
+  update();
+}
+
+function renderTrendSvg(monthly){
+  const container = document.getElementById('cost-trend');
+  if(!container) return;
+  const w=600, h=240, padding=30;
+  const maxTotal = Math.max(...monthly.map(m=>m.total));
+  const xStep = (w-padding*2)/(monthly.length-1);
+  let d="";
+  monthly.forEach((m,i)=>{
+    const x = padding + i*xStep;
+    const y = h - padding - (m.total/maxTotal)*(h-padding*2);
+    d += i===0?`M${x},${y}`:` L${x},${y}`;
+  });
+  const bars = monthly.map((m,i)=>{
+    const x = padding + i*xStep - 10;
+    const partsHeight = (m.parts/maxTotal)*(h-padding*2);
+    const laborHeight = (m.labor/maxTotal)*(h-padding*2);
+    const yParts = h - padding - partsHeight;
+    const yLabor = yParts + (partsHeight - laborHeight);
+    return `<g>
+      <rect x="${x}" y="${yParts}" width="8" height="${partsHeight}" class="fill-blue-200"></rect>
+      <rect x="${x+8}" y="${yLabor}" width="8" height="${laborHeight}" class="fill-blue-400"></rect>
+    </g>`;
+  }).join('');
+
+  container.innerHTML = `<svg viewBox="0 0 ${w} ${h}" aria-label="Maintenance cost trend"><desc>Total vs Parts vs Labor for last 12 months</desc>
+    <path d="${d}" fill="none" stroke="#2563eb" stroke-width="2" />
+    ${bars}
+  </svg>`;
+}
+
+function renderRankings(rankings){
+  const high = document.querySelector('#rank-high tbody');
+  const repairs = document.querySelector('#rank-repairs tbody');
+  if(!rankings.highestCost.length) {
+    high.innerHTML = `<tr><td colspan="4" class="text-center text-sm text-gray-500 p-2">No data</td></tr>`;
+  } else {
+    high.innerHTML = rankings.highestCost.map(r=>`<tr class="hover:bg-gray-50">
+      <td class="p-2">${r.rank}</td>
+      <td class="p-2">${r.truckPlate}</td>
+      <td class="p-2">${r.model}</td>
+      <td class="p-2 text-right">${formatCurrency(r.value)}</td>
+    </tr>`).join('');
+  }
+  if(!rankings.mostRepairs.length) {
+    repairs.innerHTML = `<tr><td colspan="4" class="text-center text-sm text-gray-500 p-2">No data</td></tr>`;
+  } else {
+    repairs.innerHTML = rankings.mostRepairs.map(r=>`<tr class="hover:bg-gray-50">
+      <td class="p-2">${r.rank}</td>
+      <td class="p-2">${r.truckPlate}</td>
+      <td class="p-2">${r.model}</td>
+      <td class="p-2 text-right">${r.value}</td>
+    </tr>`).join('');
+  }
+}
+
+function renderLowStock(items){
+  const list = document.getElementById('low-stock-list');
+  if(!items.length){
+    list.innerHTML = `<li class="text-sm text-gray-500 p-4">No low stock items</li>`;
+    return;
+  }
+  list.innerHTML = items.map(i=>`<li class="p-4 border-b last:border-0">
+    <p class="font-medium">${i.name} <span class="text-xs text-gray-500">(${i.sku})</span></p>
+    <p class="text-sm text-gray-600">On hand: ${i.onHand} | Min: ${i.minLevel}</p>
+    <p class="text-xs text-gray-500">Locations: ${i.locations.join(', ')}</p>
+  </li>`).join('');
+}
+
+function renderActivity(items){
+  const list = document.getElementById('activity-feed');
+  if(!items.length){
+    list.innerHTML = `<li class="text-sm text-gray-500 p-4">No recent activity</li>`;
+    return;
+  }
+  list.innerHTML = items.map(a=>`<li class="p-4 border-b last:border-0 flex justify-between" tabindex="0">
+    <span class="mr-2" aria-hidden="true">${iconFor(a.icon)}</span>
+    <p class="flex-1 text-sm">${a.text}</p>
+    <time class="text-xs text-gray-500">${timeAgo(a.timestamp)}</time>
+  </li>`).join('');
+}
+
+function iconFor(type){
+  switch(type){
+    case 'ticket': return '🎫';
+    case 'wo': return '🧰';
+    case 'pr': return '📝';
+    default: return 'ℹ️';
+  }
+}

--- a/public/assets/js/mockApi.js
+++ b/public/assets/js/mockApi.js
@@ -1,0 +1,5 @@
+export async function getAdminDashboardData() {
+  const res = await fetch('/assets/data/admin_dashboard.json');
+  if (!res.ok) throw new Error('Failed to load dashboard data');
+  return res.json();
+}

--- a/public/assets/js/utils.js
+++ b/public/assets/js/utils.js
@@ -1,0 +1,30 @@
+export function formatCurrency(num) {
+  return new Intl.NumberFormat('en-PH', { style: 'currency', currency: 'PHP', maximumFractionDigits: 0 }).format(num);
+}
+
+export function timeAgo(isoString) {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return `${seconds}s ago`;
+}
+
+export function ageBadgeClasses(days) {
+  if (days < 3) return 'bg-gray-100 text-gray-600';
+  if (days < 7) return 'bg-amber-100 text-amber-700';
+  return 'bg-red-100 text-red-700';
+}
+
+export function severityClasses(sev) {
+  switch(sev) {
+    case 'red': return 'bg-red-50 text-red-600';
+    case 'amber': return 'bg-amber-50 text-amber-600';
+    case 'green': return 'bg-green-50 text-green-600';
+    default: return 'bg-gray-50 text-gray-600';
+  }
+}

--- a/public/includes/footer.php
+++ b/public/includes/footer.php
@@ -1,0 +1,8 @@
+</main>
+</div>
+<footer class="text-center text-xs text-gray-500 p-4">&copy; 2025 TRMS</footer>
+<script type="module" src="/assets/js/utils.js"></script>
+<script type="module" src="/assets/js/mockApi.js"></script>
+<script type="module" src="/assets/js/dashboard.js"></script>
+</body>
+</html>

--- a/public/includes/header.php
+++ b/public/includes/header.php
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900">
+<header class="bg-white shadow p-4 flex items-center justify-between">
+  <h1 class="font-semibold">Admin Dashboard</h1>
+</header>
+<div class="flex flex-col md:flex-row">

--- a/public/includes/sidebar.php
+++ b/public/includes/sidebar.php
@@ -1,0 +1,15 @@
+<aside class="bg-white w-full md:w-64 border-b md:border-b-0 md:border-r" aria-label="Sidebar">
+  <nav class="p-4">
+    <ul class="flex md:flex-col space-x-4 md:space-x-0 md:space-y-2">
+      <li><a href="/admin/dashboard.php" class="block px-2 py-1 rounded bg-blue-50 text-blue-600">Dashboard</a></li>
+      <li><a href="#" class="block px-2 py-1 rounded text-gray-700">Users</a></li>
+      <li><a href="#" class="block px-2 py-1 rounded text-gray-700">Trucks</a></li>
+      <li><a href="#" class="block px-2 py-1 rounded text-gray-700">Parts &amp; Inventory</a></li>
+      <li><a href="#" class="block px-2 py-1 rounded text-gray-700">Purchase Requests</a></li>
+      <li><a href="#" class="block px-2 py-1 rounded text-gray-700">Work Orders</a></li>
+      <li><a href="#" class="block px-2 py-1 rounded text-gray-700">Reports</a></li>
+      <li><a href="#" class="block px-2 py-1 rounded text-gray-700">Settings</a></li>
+    </ul>
+  </nav>
+</aside>
+<main class="flex-1">

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__ . '/includes/header.php';
+require_once __DIR__ . '/includes/sidebar.php';
+?>
+<div class="p-6">
+  <p class="text-lg">Welcome. Go to <a href="/admin/dashboard.php" class="text-blue-600 underline">Admin Dashboard</a>.</p>
+</div>
+<?php require_once __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- implement PHP layout with header, sidebar, footer for admin dashboard
- render admin dashboard widgets using Tailwind and vanilla JS modules
- supply mock JSON data and utility helpers for formatting

## Testing
- `php -l public/includes/header.php`
- `php -l public/includes/sidebar.php`
- `php -l public/includes/footer.php`
- `php -l public/admin/dashboard.php`
- `php -l public/index.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aac15e4cfc832eaf07632e648a90d6