### PR TITLE
Fix login handler path so dashboard accessible

### DIFF
--- a/public/auth/login-handler.php
+++ b/public/auth/login-handler.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../../app/auth-handler/login-handler.php';

--- a/public/auth/login.php
+++ b/public/auth/login.php
@@ -34,7 +34,7 @@ if (empty($_SESSION['csrf'])) {
 
         <h2 class="<?php echo $loginStyle['heading']; ?>">Log in to your account</h2>
 
-        <form action="/trms/app/auth-handler/login-handler.php" method="POST" class="<?php echo $loginStyle['form']; ?>">
+        <form action="login-handler.php" method="POST" class="<?php echo $loginStyle['form']; ?>">
             <!-- Hidden CSRF token field -->
             <input type="hidden" name="csrf" value="<?= htmlspecialchars($_SESSION['csrf'], ENT_QUOTES, 'UTF-8') ?>">
 


### PR DESCRIPTION
## Summary
- fix login form to post to a public login handler
- expose login handler under `public/auth` to avoid 404 errors

## Testing
- `php -l public/auth/login.php && php -l public/auth/login-handler.php`


------
https://chatgpt.com/codex/tasks/task_b_68ac61273f20832e8cd119b4b4b9e12e